### PR TITLE
switched to edi portal for download not packages.lternet.edu

### DIFF
--- a/R/get.R
+++ b/R/get.R
@@ -20,17 +20,21 @@ lagosne_get <- function(version, overwrite = FALSE, dest_folder = NA){
     return(invisible("LAGOS is the best"))
   }
 
-  baseurl <- "http://pasta.lternet.edu/package/data/eml/edi/"
-
-  locus_base  <- paste0(baseurl, c("100/4"))
-  locus_dir   <- get_lagos_module(locus_base, "locus", overwrite)
-
-  limno_base <- paste0(baseurl, c("101/2"))
-  limno_dir  <- get_lagos_module(limno_base, "limno", overwrite)
-
-  geo_base <- paste0(baseurl, c("99/5"))
-  geo_dir  <- get_lagos_module(geo_base, "geo", overwrite)
-
+    edi_baseurl <- "https://portal.edirepository.org/nis/dataviewer?packageid="
+    pasta_baseurl <- "http://pasta.lternet.edu/package/data/eml/edi/"
+    
+    locus_base_edi  <- paste0(edi_baseurl, c("edi.100.4"))
+    locus_base_pasta <- paste0(pasta_baseurl, "100/4")
+    locus_dir   <- get_lagos_module(locus_base_edi, locus_base_pasta, "locus", overwrite)
+    
+    limno_base_edi <- paste0(edi_baseurl, c("edi.101.2"))
+    limno_base_pasta <- paste0(pasta_baseurl, "101/2")
+    limno_dir  <- get_lagos_module(limno_base_edi, limno_base_pasta, "limno", overwrite)
+    
+    geo_base_edi <- paste0(edi_baseurl, c("edi.99.5"))
+    geo_base_pasta <- paste0(pasta_baseurl, "99/5")
+    geo_dir  <- get_lagos_module(geo_base_edi, geo_base_pasta, "geo", overwrite)
+  
   dir.create(lagos_path(), showWarnings = FALSE)
 
   lagosne_compile(version = version,

--- a/R/utils.R
+++ b/R/utils.R
@@ -223,9 +223,9 @@ get_file_names <- function(url){
   gsub('\\"', "", res)
 }
 
-get_lagos_module <- function(url, folder_name, overwrite){
-  files <- suppressWarnings(paste0(url, "/",
-                            readLines(url)))
+get_lagos_module <- function(edi_url, pasta_url, folder_name, overwrite){
+  files <- suppressWarnings(paste0(edi_url, "&entityid=",
+                            readLines(pasta_url)))
 
   file_names <- sapply(files, get_file_names)
 


### PR DESCRIPTION
Shifts download to edi from pasta.  The direct download from pasta.lternet was not making more restrictive firewalls (e.g. EPA, USGS) happy.  Using the edi downloads appears to fix this.

Hope this helps!

Also, I didn't update version or anything in DESCRIPTION.  Happy to do so if you want me to bump that for this PR.