### PR TITLE
Replaced references to legacy versions of LAGOSNE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: LAGOSNE
 Title: Interface to the Lake Multi-Scaled Geospatial and Temporal Database
-Version: 2.0.1
+Version: 2.0.2
 Authors@R: c(
     person("Joseph", "Stachelek", 
     email = "stachel2@msu.edu", 
@@ -42,7 +42,7 @@ Suggests: testthat,
 License: GPL
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 VignetteBuilder: R.rsp,
     knitr
 Language: en-US

--- a/R/select.R
+++ b/R/select.R
@@ -2,7 +2,7 @@
 #'
 #' Select and filter LAGOSNE data with keyword helpers.
 #'
-#' @param dt data.frame
+#' @param dt data.frame of local copy of LAGOSNE data.  Can be loaded with \code{\link{lagosne_load}} and will use version as specified in \code{\link{lagosne_version}}.
 #' @param table character name of a dt table
 #' @param vars character vector of specific column names to select from table
 #' @param categories what type of variables should be kept. Note not all scale-category options are available. Variable categories include:
@@ -41,7 +41,7 @@
 #' }
 
 lagosne_select <- function(table = NULL, vars = NULL, categories = NULL,
-                         dt = lagosne_load("1.087.1")){
+                         dt = lagosne_load(lagosne_version())){
 
   # sanitize inputs ####
   is_not_char_args <- c(!(is.null(table) | is.character(table)),

--- a/data-raw/create_lagos_extent.R
+++ b/data-raw/create_lagos_extent.R
@@ -2,7 +2,7 @@ library(concaveman)
 library(LAGOSNE)
 library(sf)
 
-dt <- LAGOSNE::lagosne_load("1.087.1")
+dt <- LAGOSNE::lagosne_load(lagosne_version())
 dt <- coordinatize(dt$locus)
 
 lg_extent <- concaveman(

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -22,12 +22,13 @@ citEntry(entry = "Manual",
   title        = "LAGOSNE: Interface to the Lake Multi-Scaled Geospatial and Temporal Database",
   author       = personList(
                    as.person("Joseph Stachelek"),
-                   as.person("Samantha Oliver")),
-  year         = "2017",
-  note         = "R package version 1.1.0",
+                   as.person("Samantha Oliver"),
+                   as.person("Farzan Masrour")),
+  year         = "2019",
+  note         = "R package version 2.0.2",
   url          = "https://cran.r-project.org/package=LAGOSNE",
   textVersion  =
-  paste("Stachelek J., Oliver S. 2017. LAGOSNE: Interface to the Lake Multi-scaled Geospatial and Temporal Database. R package version 1.1.0. https://cran.r-project.org/package=LAGOSNE
+  paste("Stachelek J., Oliver S., Masrour, F. 2019. LAGOSNE: Interface to the Lake Multi-scaled Geospatial and Temporal Database. R package version 2.0.2. https://cran.r-project.org/package=LAGOSNE
   ")
 )
 

--- a/man/lagosne_select.Rd
+++ b/man/lagosne_select.Rd
@@ -8,7 +8,7 @@ lagosne_select(
   table = NULL,
   vars = NULL,
   categories = NULL,
-  dt = lagosne_load("1.087.1")
+  dt = lagosne_load(lagosne_version())
 )
 }
 \arguments{
@@ -33,7 +33,7 @@ lagosne_select(
     \item "streams" - all stream/river connectivity metrics from the .conn tables
 }}
 
-\item{dt}{data.frame}
+\item{dt}{data.frame of local copy of LAGOSNE data.  Can be loaded with \code{\link{lagosne_load}} and will use version as specified in \code{\link{lagosne_version}}.}
 }
 \description{
 Select and filter LAGOSNE data with keyword helpers.


### PR DESCRIPTION
Noticed that lagosne_select and create_lagos_extent.R were both still referencing version 1.087.1.  This was the default behavior in lagosne_select and causes an error if the dt is not explicitly used.  I updated both of these references from 1.087.1 to use lagosne_version() instead.  

Also bumped version, added some documentation in lagosne_select, and updated CITATION.  

Thanks again for a great package.  Got a paper in review now that uses LAGOSNE (and that is how I noticed this issue).  Hope to have it out in 4-6 months or so.