### PR TITLE
Bug in reading entity ids from pasta

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Imports: dplyr (>= 0.7.0),
     memoise,
     rlang,
     progress,
-    qs
+    qs,
+    httr
 Suggests: testthat,
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: LAGOSNE
 Title: Interface to the Lake Multi-Scaled Geospatial and Temporal Database
-Version: 2.0.2
+Version: 2.0.3
 Authors@R: c(
     person("Jemma", "Stachelek", 
     email = "stachel2@msu.edu", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# LAGOSNE 2.0.3
+
+## BUG FIXES
+
+* readLines was not able to correctly readl from pasta. Switched to httr::GET.
+
 # LAGOSNE 2.0.2
 
 ## MAJOR IMPROVEMENTS

--- a/R/get.R
+++ b/R/get.R
@@ -38,7 +38,7 @@ between R sessions. \n")
   }
 
     edi_baseurl   <- "https://portal.edirepository.org/nis/dataviewer?packageid="
-    pasta_baseurl <- "http://pasta.lternet.edu/package/data/eml/edi/"
+    pasta_baseurl <- "https://pasta.lternet.edu/package/data/eml/edi/"
 
     message("Downloading the 'locus' module ...")
     locus_base_edi   <- paste0(edi_baseurl, c("edi.100.4"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -237,8 +237,10 @@ get_file_names <- function(url){
 
 get_lagos_module <- function(edi_url, pasta_url, folder_name, overwrite){
 
-  files <- suppressWarnings(paste0(edi_url, "&entityid=",
-                            readLines(pasta_url)))
+  id <- httr::content(httr::GET(pasta_url), encoding = "UTF-8")
+  id <- strsplit(id, "\n")[[1]]
+  files <- suppressWarnings(paste0(edi_url, "&entityid=", id))
+
   file_names <- sapply(files, get_file_names)
 
   files      <- files[!is.na(file_names)]


### PR DESCRIPTION
Was getting an SSL connect error when trying to use readLines to read the pasta_url.  Switched over to httr::GET.